### PR TITLE
fix: Fix ProtectedRoute redirect behavior for waitlist access

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -4,10 +4,19 @@ import { Button } from "@/components/ui/button";
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
+const ACCESS_CODE_STORAGE_KEY = "essentials_access_code_validated";
+
 export default function AuthPage() {
   const router = useRouter();
 
   useEffect(() => {
+    // Check if user has valid access code
+    const storedValidation = localStorage.getItem(ACCESS_CODE_STORAGE_KEY);
+    if (storedValidation !== "true") {
+      // Redirect to root if no valid access code
+      router.push('/');
+      return;
+    }
     // Prevent scrolling on this page
     const originalOverflow = document.body.style.overflow;
     const originalPosition = document.body.style.position;

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -5,7 +5,7 @@ import { useRouter, usePathname } from 'next/navigation';
 import { supabase } from '@/lib/supabase/client';
 
 // List of public routes that don't require authentication
-const publicRoutes = ['/auth', '/api/trpc', '/terms-of-service', '/privacy-policy'];
+const publicRoutes = ['/', '/auth', '/api/trpc', '/terms-of-service', '/privacy-policy'];
 
 export default function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const router = useRouter();
@@ -32,7 +32,7 @@ export default function ProtectedRoute({ children }: { children: React.ReactNode
     // Listen for auth changes
     const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
       if (event === 'SIGNED_OUT') {
-        router.push('/auth');
+        router.push('/');
       }
     });
 


### PR DESCRIPTION
- Add root path (/) to publicRoutes to allow unauthenticated access to waitlist
- Change sign-out redirect from /auth to / (root) to send users to waitlist
- Add access code protection to /auth page to prevent unauthorized access

Fixes #60