### PR TITLE
feat: add admin button to navbar

### DIFF
--- a/src/app/_components/DesktopNavbar.tsx
+++ b/src/app/_components/DesktopNavbar.tsx
@@ -2,6 +2,8 @@
 import { cn } from "@/lib/utils"
 import type { NavigationItem } from "@/app/dashboard/layout"
 import { useRouter } from "next/navigation"
+import { api } from "@/trpc/react"
+import { Settings } from "lucide-react"
 
 
 
@@ -12,6 +14,8 @@ interface DesktopNavbarProps {
 
 export default function DesktopNavbar({ navigationItems, currentTab }: DesktopNavbarProps) {
   const router = useRouter()
+  const { data: user } = api.user.getUser.useQuery()
+  
   return (
     <div className="hidden md:block fixed top-0 left-0 right-0 z-50 bg-white border-b border-gray-200 shadow-sm">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -46,6 +50,20 @@ export default function DesktopNavbar({ navigationItems, currentTab }: DesktopNa
                 </button>
               )
             })}
+            
+            {/* Admin Button - Only show if user is admin */}
+            {user?.role === "admin" && (
+              <button
+                onClick={() => router.push("/admin")}
+                className={cn(
+                  "flex items-center space-x-2 px-3 py-2 rounded-md text-sm font-medium transition-all duration-200",
+                  "text-gray-500 hover:text-gray-700 hover:bg-gray-100"
+                )}
+              >
+                <Settings className="h-4 w-4 transition-colors text-gray-500" />
+                <span className="transition-colors">Admin</span>
+              </button>
+            )}
           </nav>
         </div>
       </div>

--- a/src/app/_components/MobileNavbar.tsx
+++ b/src/app/_components/MobileNavbar.tsx
@@ -2,6 +2,8 @@
 import { cn } from "@/lib/utils"
 import type { NavigationItem } from "../dashboard/layout"
 import { useRouter } from "next/navigation"
+import { api } from "@/trpc/react"
+import { Settings } from "lucide-react"
 
 
 interface MobileNavbarProps {
@@ -11,6 +13,8 @@ interface MobileNavbarProps {
 
 export default function MobileNavbar({ currentTab, navigationItems }: MobileNavbarProps) {
   const router = useRouter()
+  const { data: user } = api.user.getUser.useQuery()
+  
   return (
     <div
       className="fixed bottom-0 left-0 right-0 z-50 bg-white border-t border-gray-200 shadow-lg"
@@ -42,6 +46,22 @@ export default function MobileNavbar({ currentTab, navigationItems }: MobileNavb
             </button>
           )
         })}
+        
+        {/* Admin Button - Only show if user is admin */}
+        {user?.role === "admin" && (
+          <button
+            onClick={() => router.push("/admin")}
+            className={cn(
+              "flex flex-col items-center justify-center gap-1 px-3 py-2 rounded-lg transition-all duration-200",
+              "text-gray-500 hover:text-gray-700 hover:bg-gray-100"
+            )}
+          >
+            <Settings className="h-5 w-5 transition-colors text-gray-500" />
+            <span className="text-xs font-medium transition-colors text-gray-500">
+              Admin
+            </span>
+          </button>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
Add conditional admin button to both desktop and mobile navbars that appears when user.role === 'admin' and navigates to /admin page.

- Added tRPC user.getUser query to fetch user role data
- Added Settings icon from lucide-react for admin button
- Implemented conditional rendering based on admin role
- Added navigation to existing /admin route
- Consistent styling with existing navbar components

Resolves #70