### PR TITLE
fix: disable waitlist inputs when access code mode is active

### DIFF
--- a/src/app/_components/waitlist/WaitlistForm.tsx
+++ b/src/app/_components/waitlist/WaitlistForm.tsx
@@ -181,6 +181,7 @@ export default function WaitlistForm() {
                   {...register("fullName")}
                   placeholder="Enter your full name"
                   className={errors.fullName ? "border-red-500" : ""}
+                  disabled={showAccessCode}
                 />
                 {errors.fullName && (
                   <p className="text-red-500 text-sm">{errors.fullName.message}</p>
@@ -197,6 +198,7 @@ export default function WaitlistForm() {
                   {...register("email")}
                   placeholder="Enter your email address"
                   className={errors.email ? "border-red-500" : ""}
+                  disabled={showAccessCode}
                 />
                 {errors.email && (
                   <p className="text-red-500 text-sm">{errors.email.message}</p>
@@ -256,7 +258,7 @@ export default function WaitlistForm() {
               <Button
                 type="submit"
                 className="w-full"
-                disabled={submitWaitlistMutation.isPending}
+                disabled={submitWaitlistMutation.isPending || showAccessCode}
               >
                 {submitWaitlistMutation.isPending ? (
                   <>


### PR DESCRIPTION
When user clicks 'Enter Code' to enter access code mode, the name and email inputs are now disabled along with the 'Join Waitlist' button. This prevents the confusing UX where users could interact with both the waitlist form and access code input simultaneously.

Changes:
- Added disabled={showAccessCode} to fullName input
- Added disabled={showAccessCode} to email input
- Added showAccessCode condition to Join Waitlist button disabled state

Fixes #80